### PR TITLE
Added static linking support to files

### DIFF
--- a/winfsp-sys/wrapper.h
+++ b/winfsp-sys/wrapper.h
@@ -1,2 +1,0 @@
-#include <winfsp/winfsp.h>
-#include <winfsp/fsctl.h>


### PR DESCRIPTION
Added static linking support to files

I tested out the building, and all configurations build successfully for me.

A feature flag `dylib` was added which is by default disabled (static linking is default functionality). This flag is used to enable dynamic linking during build. It works in conjunction with system flag to either use the local dynamic/static libs, or the system dynamic/static libs.

Please carefully review this PR. I can't guarantee I got everything perfect!

_I have not gotten to the point where I tested if static libs work in real production code, even though this builds 100%_