### PR TITLE
Soundness fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,7 +662,7 @@ source = "git+https://github.com/microsoft/windows-rs?branch=master#58eaa528e13b
 
 [[package]]
 name = "winfsp"
-version = "0.9.1+winfsp-2.0"
+version = "0.9.3+winfsp-2.0"
 dependencies = [
  "bytemuck",
  "paste",

--- a/filesystems/ntptfs-winfsp-rs/Cargo.toml
+++ b/filesystems/ntptfs-winfsp-rs/Cargo.toml
@@ -17,6 +17,5 @@ widestring = "1"
 winfsp = { path = "../../winfsp", features = ["debug", "system"] }
 anyhow = "1"
 
-ntapi = "0.4.1"
 [build-dependencies]
 winfsp = { path = "../../winfsp", features = ["delayload"] }

--- a/filesystems/ntptfs-winfsp-rs/src/fs/context.rs
+++ b/filesystems/ntptfs-winfsp-rs/src/fs/context.rs
@@ -39,7 +39,10 @@ use windows::Win32::System::SystemServices::MAXIMUM_ALLOWED;
 use windows::Win32::System::WindowsProgramming::FILE_INFORMATION_CLASS;
 
 use winfsp::constants::FspCleanupFlags::FspCleanupDelete;
-use winfsp::filesystem::{DirInfo, DirMarker, FileInfo, FileSecurity, FileSystemContext, ModificationDescriptor, OpenFileInfo, StreamInfo, VolumeInfo, WideNameInfo};
+use winfsp::filesystem::{
+    DirInfo, DirMarker, FileInfo, FileSecurity, FileSystemContext, ModificationDescriptor,
+    OpenFileInfo, StreamInfo, VolumeInfo, WideNameInfo,
+};
 use winfsp::host::VolumeParams;
 use winfsp::util::Win32SafeHandle;
 use winfsp::FspError;
@@ -428,7 +431,7 @@ impl FileSystemContext for NtPassthroughContext {
         file_info: &mut FileInfo,
     ) -> winfsp::Result<()> {
         let Some(context) = context else {
-            return Ok(())
+            return Ok(());
         };
 
         lfs::lfs_flush(context.handle())?;

--- a/filesystems/ntptfs-winfsp-rs/src/fs/ntptfs.rs
+++ b/filesystems/ntptfs-winfsp-rs/src/fs/ntptfs.rs
@@ -3,7 +3,7 @@ use std::io::ErrorKind;
 
 use std::path::Path;
 
-use winfsp::host::{DebugMode, FileContextMode, FileSystemHost, FileSystemParams, VolumeParams};
+use winfsp::host::{DebugMode, FileSystemHost, FileSystemParams, VolumeParams};
 
 /// An passthrough filesystem using the NT API.
 pub struct NtPassthroughFilesystem {
@@ -19,7 +19,7 @@ impl NtPassthroughFilesystem {
         }
         let canonical_path = std::fs::canonicalize(&path)?;
 
-        let mut volume_params = VolumeParams::new(FileContextMode::Descriptor);
+        let mut volume_params = VolumeParams::new();
         volume_params
             .prefix(volume_prefix)
             .filesystem_name("ntptfs");

--- a/winfsp/src/host/volumeparams.rs
+++ b/winfsp/src/host/volumeparams.rs
@@ -8,22 +8,6 @@ use winfsp_sys::FSP_FSCTL_VOLUME_PARAMS;
 /// Parameters that control how the WinFSP volume is mounted and processes requests.
 pub struct VolumeParams(pub(crate) FSP_FSCTL_VOLUME_PARAMS);
 
-/// Sets whether the FileContext represents a file node, or a file descriptor.
-///
-/// A file node uniquely identifies an open file, and opening the same file name should always yield
-/// the same file node value for as long as the file with that name remains open anywhere in the system.
-///
-/// A file descriptor identifies an open instance of a file. Opening the same file name may yield
-/// a different file descriptor. This is WinFSP's `UmFileContextIsUserContext2` mode.
-///
-/// WinFSP's `UmFileContextIsFullContext` mode is not supported.
-pub enum FileContextMode {
-    /// The file context is a node, and opening the same file name will always yield the same value.
-    Node,
-    /// The file context is a descriptor, and opening the same file name may yield a different value.
-    Descriptor,
-}
-
 macro_rules! make_setters {
     (
         $(
@@ -56,20 +40,20 @@ macro_rules! make_setters {
         )+
     };
 }
+
+impl Default for VolumeParams {
+    fn default() -> Self {
+        VolumeParams::new()
+    }
+}
+
 impl VolumeParams {
-    pub fn new(mode: FileContextMode) -> Self {
+    pub fn new() -> Self {
         let mut params = FSP_FSCTL_VOLUME_PARAMS::default();
 
-        match mode {
-            FileContextMode::Node => {
-                params.set_UmFileContextIsFullContext(0);
-                params.set_UmFileContextIsUserContext2(0)
-            }
-            FileContextMode::Descriptor => {
-                params.set_UmFileContextIsFullContext(0);
-                params.set_UmFileContextIsUserContext2(1);
-            }
-        }
+        // descriptor mode
+        params.set_UmFileContextIsFullContext(0);
+        params.set_UmFileContextIsUserContext2(1);
         VolumeParams(params)
     }
 

--- a/winfsp/src/service.rs
+++ b/winfsp/src/service.rs
@@ -153,7 +153,7 @@ impl<T> FileSystemServiceBuilder<T> {
         service_name: impl AsRef<OsStr>,
         _init: FspInit,
     ) -> Result<FileSystemService<T>> {
-        let mut service = UnsafeCell::new(std::ptr::null_mut());
+        let service = UnsafeCell::new(std::ptr::null_mut());
         let service_name = HSTRING::from(service_name.as_ref());
         let result = unsafe {
             // SAFETY: service_name is never mutated.


### PR DESCRIPTION
According to WinFSP documentation, `FileContextMode::Node` has the following behaviour

> When both of these flags are unset (default), the FileContext parameter represents the file node. The file node is a void pointer (or an integer that can fit in a pointer) that is used to uniquely identify an open file. Opening the same file name should always yield the same file node value for as long as the file with that name remains open anywhere in the system.

As a result it will call `Close` on the same pointer multiple times to decrease the refcount of the file pointed to by the node. With the current design of the `winfsp` crate, there is no possible way to transparently refcount the output `FileContexts` of `Open` or `Create` to make `FileContextMode::Node` sound, since `FileSystemContext` is both opaque, and only sound on `Arc` if `Arc` originates from the same file.

This PR removes the ability for users to choose between `FileContextMode`s, and always defaults to `FileContextMode::Descriptor`, effectively. This is a breaking change. Versions 0.9.x will be deprecated, with a final maintenance release with a compiler error on use of  `FileContextMode::Node`.


Fixes #20.



