### PR TITLE
winfsp: remove async_trait and use RPTIT for async-io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,17 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
-name = "async-trait"
-version = "0.1.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,7 +329,6 @@ name = "ntptfs-winfsp-rs"
 version = "0.1.0-alpha"
 dependencies = [
  "anyhow",
- "async-trait",
  "bytemuck",
  "clap",
  "tokio",
@@ -823,9 +811,8 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winfsp"
-version = "0.10.0-beta.4+winfsp-2.0"
+version = "0.10.0+winfsp-2.0"
 dependencies = [
- "async-trait",
  "bytemuck",
  "paste",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winfsp"
-version = "0.10.0+winfsp-2.0"
+version = "0.11.0+winfsp-2.0"
 dependencies = [
  "bytemuck",
  "paste",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ feature. The path will automatically be determined via the Registry.
 
 ```toml
 [dependencies.winfsp]
-version = "0.10"
+version = "0.11"
 features = ["system"]
 ```
 ### Delay-loading
@@ -29,7 +29,7 @@ the build script. This is required for winfsp-rs.
 #### Cargo.toml
 ```toml
 [build-dependencies]
-winfsp = "0.10"
+winfsp = "0.11"
 ```
 
 #### build.rs

--- a/filesystems/ntptfs-winfsp-rs/Cargo.toml
+++ b/filesystems/ntptfs-winfsp-rs/Cargo.toml
@@ -16,7 +16,6 @@ widestring = "1"
 winfsp = { path = "../../winfsp", features = ["debug", "system", "full"] }
 anyhow = "1"
 tokio =  { version = "1.32.0", features = ["rt", "rt-multi-thread"] }
-async-trait = { version = "0.1.73" }
 
 [build-dependencies]
 winfsp = { path = "../../winfsp", features = ["delayload"] }

--- a/filesystems/ntptfs-winfsp-rs/src/fs/context.rs
+++ b/filesystems/ntptfs-winfsp-rs/src/fs/context.rs
@@ -408,7 +408,9 @@ impl FileSystemContext for NtPassthroughContext {
             Err(e) => Err(e),
         }?;
 
-        if let Some(extra_buffer) = extra_buffer && extra_buffer_is_reparse_point {
+        if let Some(extra_buffer) = extra_buffer
+            && extra_buffer_is_reparse_point
+        {
             lfs::lfs_fs_control_file(*handle, FSCTL_SET_REPARSE_POINT, Some(extra_buffer), None)?;
         }
 
@@ -898,13 +900,7 @@ impl FileSystemContext for NtPassthroughContext {
     }
 }
 
-use async_trait::async_trait;
-#[async_trait]
 impl AsyncFileSystemContext for NtPassthroughContext {
-    fn spawn_task(&self, future: impl Future<Output = ()> + Send + 'static) {
-        let _ = self.executor.spawn(future);
-    }
-
     async fn read_async(
         &self,
         context: &Self::FileContext,
@@ -1020,5 +1016,9 @@ impl AsyncFileSystemContext for NtPassthroughContext {
             }
         }
         Ok(context.dir_buffer().read(marker, buffer))
+    }
+
+    fn spawn_task(&self, future: impl Future<Output = ()> + Send + 'static) {
+        let _ = self.executor.spawn(future);
     }
 }

--- a/filesystems/ntptfs-winfsp-rs/src/native/lfs/mod.rs
+++ b/filesystems/ntptfs-winfsp-rs/src/native/lfs/mod.rs
@@ -455,17 +455,19 @@ pub fn lfs_get_file_info<'a, P: Into<MaybeOpenFileInfo<'a>>>(
         return Ok(());
     }
 
-    if let (Some(root_prefix_length_bytes), MaybeOpenFileInfo::OpenFileInfo(open_file))
-            = (root_prefix_length, maybe_file_info)
-                && root_prefix_length_bytes != u32::MAX
-                && open_file.normalized_name_size() > (size_of::<u16>() as u32 + file_all_info.NameInformation.FileNameLength) as u16
-                && root_prefix_length_bytes <= file_all_info.NameInformation.FileNameLength
-        {
-
+    if let (Some(root_prefix_length_bytes), MaybeOpenFileInfo::OpenFileInfo(open_file)) =
+        (root_prefix_length, maybe_file_info)
+        && root_prefix_length_bytes != u32::MAX
+        && open_file.normalized_name_size()
+            > (size_of::<u16>() as u32 + file_all_info.NameInformation.FileNameLength) as u16
+        && root_prefix_length_bytes <= file_all_info.NameInformation.FileNameLength
+    {
         // get the file_name without root prefix
         let file_name = unsafe {
-            slice::from_raw_parts(file_all_info.NameInformation.FileName.as_ptr().cast::<u8>(),
-                                  file_all_info.NameInformation.FileNameLength as usize)
+            slice::from_raw_parts(
+                file_all_info.NameInformation.FileName.as_ptr().cast::<u8>(),
+                file_all_info.NameInformation.FileNameLength as usize,
+            )
         };
 
         let file_name = &file_name[(root_prefix_length_bytes as usize)..];

--- a/winfsp/Cargo.toml
+++ b/winfsp/Cargo.toml
@@ -18,7 +18,6 @@ thiserror = "1"
 paste = "1"
 static_assertions = "1.1"
 bytemuck = "1.13"
-async-trait = { version = "0.1.73", optional = true }
 
 [features]
 default = ["stable", "nightly", "windows-rs"]
@@ -35,7 +34,7 @@ nightly = ["io-error", "strict-provenance"]
 strict-provenance = []
 io-error = []
 handle-util = []
-async-io = [ "async-trait" ]
+async-io = [ ]
 full = ["stable", "nightly", "async-io"]
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/winfsp/Cargo.toml
+++ b/winfsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winfsp"
-version = "0.10.0+winfsp-2.0"
+version = "0.11.0+winfsp-2.0"
 edition = "2021"
 readme = "../README.md"
 license = "GPL-3.0"

--- a/winfsp/src/host/fshost.rs
+++ b/winfsp/src/host/fshost.rs
@@ -105,8 +105,7 @@ impl FileSystemParams {
 /// should start within the context of a service.
 pub struct FileSystemHost<'ctx>(
     NonNull<FSP_FILE_SYSTEM>,
-    #[allow(dead_code)]
-    Option<Timer>,
+    #[allow(dead_code)] Option<Timer>,
     PhantomData<&'ctx FSP_FILE_SYSTEM>,
 );
 
@@ -134,7 +133,13 @@ impl FileSystemHost<'static> {
             Interface::create_with_read_directory_async::<T>()
         };
 
-        Self::new_filesystem_inner_iface(interface, volume_params, guard_strategy, debug_mode, context)
+        Self::new_filesystem_inner_iface(
+            interface,
+            volume_params,
+            guard_strategy,
+            debug_mode,
+            context,
+        )
     }
 
     /// Create a `FileSystemHost` with the default settings
@@ -172,7 +177,10 @@ impl FileSystemHost<'static> {
 
     /// Create a `FileSystemHost` with the provided notifying context implementation,
     /// host options, and polling interval, using async implementations of `read`, `write`, and `read_directory`.
-    #[cfg_attr(feature = "docsrs", doc(cfg(all(feature = "notify", feature = "async-io"))))]
+    #[cfg_attr(
+        feature = "docsrs",
+        doc(cfg(all(feature = "notify", feature = "async-io")))
+    )]
     #[cfg(all(feature = "notify", feature = "async-io"))]
     pub fn new_with_timer_async<
         T: crate::filesystem::AsyncFileSystemContext + NotifyingFileSystemContext<R>,
@@ -182,8 +190,8 @@ impl FileSystemHost<'static> {
         options: FileSystemParams,
         context: T,
     ) -> Result<Self>
-        where
-            <T as FileSystemContext>::FileContext: Sync,
+    where
+        <T as FileSystemContext>::FileContext: Sync,
     {
         let fsp_struct = Self::new_filesystem_inner_async(options, context)?;
         let timer = Timer::create::<R, T, INTERVAL>(fsp_struct)?;
@@ -261,7 +269,13 @@ impl<'ctx> FileSystemHost<'ctx> {
             Interface::create_with_read_directory::<T>()
         };
 
-        Self::new_filesystem_inner_iface(interface, volume_params, guard_strategy, debug_mode, context)
+        Self::new_filesystem_inner_iface(
+            interface,
+            volume_params,
+            guard_strategy,
+            debug_mode,
+            context,
+        )
     }
 
     /// Create a `FileSystemHost` with the default settings

--- a/winfsp/src/host/interface.rs
+++ b/winfsp/src/host/interface.rs
@@ -4,35 +4,30 @@ use std::slice;
 
 use widestring::U16CString;
 use windows::Win32::Foundation::{
-    EXCEPTION_NONCONTINUABLE_EXCEPTION, STATUS_INSUFFICIENT_RESOURCES,
-    STATUS_REPARSE, STATUS_SUCCESS,
+    EXCEPTION_NONCONTINUABLE_EXCEPTION, STATUS_INSUFFICIENT_RESOURCES, STATUS_REPARSE,
+    STATUS_SUCCESS,
 };
 use windows::Win32::Security::{GetSecurityDescriptorLength, PSECURITY_DESCRIPTOR};
 
 use crate::{error, U16CStr};
 use winfsp_sys::{
     FspFileSystemFindReparsePoint, FspFileSystemResolveReparsePoints, BOOLEAN, FSP_FILE_SYSTEM,
-    FSP_FILE_SYSTEM_INTERFACE, FSP_FSCTL_DIR_INFO, FSP_FSCTL_FILE_INFO,
-    FSP_FSCTL_VOLUME_INFO, PFILE_FULL_EA_INFORMATION, PIO_STATUS_BLOCK, PSIZE_T,
+    FSP_FILE_SYSTEM_INTERFACE, FSP_FSCTL_DIR_INFO, FSP_FSCTL_FILE_INFO, FSP_FSCTL_VOLUME_INFO,
+    PFILE_FULL_EA_INFORMATION, PIO_STATUS_BLOCK, PSIZE_T,
 };
 use winfsp_sys::{NTSTATUS as FSP_STATUS, PVOID};
 
 use crate::filesystem::{
-    DirInfo, DirMarker, FileInfo, FileSecurity, FileSystemContext,
-    ModificationDescriptor, OpenFileInfo, VolumeInfo,
+    DirInfo, DirMarker, FileInfo, FileSecurity, FileSystemContext, ModificationDescriptor,
+    OpenFileInfo, VolumeInfo,
 };
 
 #[cfg(feature = "async-io")]
+use crate::{constants::FspTransactKind, filesystem::AsyncFileSystemContext};
+#[cfg(feature = "async-io")]
 use std::sync::atomic::AtomicPtr;
 #[cfg(feature = "async-io")]
-use crate::{
-    filesystem::AsyncFileSystemContext,
-    constants::FspTransactKind,
-};
-#[cfg(feature = "async-io")]
-use windows::Win32::Foundation::{
-    STATUS_PENDING,STATUS_TRANSACTION_NOT_FOUND,
-};
+use windows::Win32::Foundation::{STATUS_PENDING, STATUS_TRANSACTION_NOT_FOUND};
 #[cfg(feature = "async-io")]
 use winfsp_sys::FSP_FSCTL_TRANSACT_RSP;
 
@@ -667,8 +662,7 @@ where
         };
 
         if !buffer.is_null() {
-            let buffer =
-                unsafe { slice::from_raw_parts(buffer as *const u8, length as usize) };
+            let buffer = unsafe { slice::from_raw_parts(buffer as *const u8, length as usize) };
             let fs = AtomicPtr::new(fs);
             let write_ft = async move {
                 let mut response = FSP_FSCTL_TRANSACT_RSP::default();

--- a/winfsp/src/notify/timer.rs
+++ b/winfsp/src/notify/timer.rs
@@ -1,5 +1,5 @@
-use crate::notify::{Notifier, NotifyingFileSystemContext};
 use crate::host::interface::FileSystemUserContext;
+use crate::notify::{Notifier, NotifyingFileSystemContext};
 use std::ptr::NonNull;
 use windows::core::Result;
 use windows::Win32::Foundation::{NTSTATUS, STATUS_SUCCESS};
@@ -56,7 +56,8 @@ unsafe extern "system" fn timer_callback<
     if fs.is_null() {
         panic!("Timer callback was passed in a null pointer")
     }
-    let context: &FileSystemUserContext<T> = unsafe { &*(*fs).UserContext.cast::<FileSystemUserContext<T>>() };
+    let context: &FileSystemUserContext<T> =
+        unsafe { &*(*fs).UserContext.cast::<FileSystemUserContext<T>>() };
     let notifier = Notifier(fs);
     if let Some(val) = context.should_notify() {
         unsafe {

--- a/winfsp/src/service.rs
+++ b/winfsp/src/service.rs
@@ -174,9 +174,7 @@ impl<T> FileSystemServiceBuilder<T> {
                 }),
             )) as *mut _)
         }
-        if result == STATUS_SUCCESS.0
-            && unsafe { !service.get().read().is_null() }
-        {
+        if result == STATUS_SUCCESS.0 && unsafe { !service.get().read().is_null() } {
             Ok(unsafe { FileSystemService::from_raw_unchecked(service.get().read()) })
         } else {
             Err(FspError::NTSTATUS(result))


### PR DESCRIPTION
use afit stabilized in Rust 1.75 rather than `async_trait`. `async_trait` consumers can continue to use the 0.10.0 series and are encouraged to move to 0.11.0