### PR TITLE
Fix lifetime issue when passing MountPoint enum to mount function

### DIFF
--- a/winfsp/src/host/fshost.rs
+++ b/winfsp/src/host/fshost.rs
@@ -39,7 +39,7 @@ where
         Self::MountPoint(s.as_ref())
     }
 }
-impl<'short, 'a> From<&'short MountPoint<'a>> for MountPoint<'a> {
+impl<'short, 'a> From<&'short MountPoint<'a>> for MountPoint<'short> {
     fn from(s: &'short MountPoint<'a>) -> Self {
         match s {
             MountPoint::MountPoint(v) => MountPoint::MountPoint(v),


### PR DESCRIPTION
Sorry I made a small mistake when implementing the `MountPoint` enum in the previous PR. This caused a lifetime issue when passing the enum directly to the mount function since that From impl wasn't general enough. Passing anything that implements `AsRef<OsStr>` still works though.

This PR should allow MountPoint to be passed directly to mount as intended.