### PR TITLE
fix: cross-platform compile failed

### DIFF
--- a/winfsp-sys/build.rs
+++ b/winfsp-sys/build.rs
@@ -13,101 +13,101 @@ static HEADER: &str = r#"
 
 #[cfg(not(feature = "system"))]
 fn local() -> String {
-  let project_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let project_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 
-  println!(
-    "cargo:rustc-link-search={}",
-    project_dir.join("winfsp/lib").to_string_lossy()
-  );
+    println!(
+        "cargo:rustc-link-search={}",
+        project_dir.join("winfsp/lib").to_string_lossy()
+    );
 
-  "--include-directory=winfsp/inc".into()
+    "--include-directory=winfsp/inc".into()
 }
 
 #[cfg(feature = "system")]
 fn system() -> String {
-  let winfsp_install = LOCAL_MACHINE
-    .open("SOFTWARE\\WOW6432Node\\WinFsp")
-    .ok()
-    .and_then(|u| u.get_value("InstallDir").ok())
-    .expect("WinFsp installation directory not found.");
-  let directory = match winfsp_install {
-    Value::String(string) => string,
-    _ => panic!("unexpected install directory"),
-  };
+    let winfsp_install = LOCAL_MACHINE
+        .open("SOFTWARE\\WOW6432Node\\WinFsp")
+        .ok()
+        .and_then(|u| u.get_value("InstallDir").ok())
+        .expect("WinFsp installation directory not found.");
+    let directory = match winfsp_install {
+        Value::String(string) => string,
+        _ => panic!("unexpected install directory"),
+    };
 
-  println!("cargo:rustc-link-search={}/lib", directory);
+    println!("cargo:rustc-link-search={}/lib", directory);
 
-  format!("--include-directory={}/inc", directory)
+    format!("--include-directory={}/inc", directory)
 }
 
 fn main() {
-  let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-  // host needs to be windows
-  if cfg!(feature = "docsrs") {
-    println!("cargo:warning=WinFSP does not build on any operating system but Windows. This feature is meant for docs.rs only. It will not link when compiled into a binary.");
-    File::create(out_dir.join("bindings.rs")).unwrap();
-    return;
-  }
+    // host needs to be windows
+    if cfg!(feature = "docsrs") {
+        println!("cargo:warning=WinFSP does not build on any operating system but Windows. This feature is meant for docs.rs only. It will not link when compiled into a binary.");
+        File::create(out_dir.join("bindings.rs")).unwrap();
+        return;
+    }
 
-  // Use the target OS configuration instead of the host OS configuration to enable cross-platform compilation
-  let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "unknown".to_string());
-  let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "unknown".to_string());
-  let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_else(|_| "unknown".to_string());
+    // Use the target OS configuration instead of the host OS configuration to enable cross-platform compilation
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "unknown".to_string());
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "unknown".to_string());
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_else(|_| "unknown".to_string());
 
-  if target_os != "windows" {
-    panic!("WinFSP is only supported on Windows.");
-  }
+    if target_os != "windows" {
+        panic!("WinFSP is only supported on Windows.");
+    }
 
-  #[cfg(feature = "system")]
-  let link_include = system();
-  #[cfg(not(feature = "system"))]
-  let link_include = local();
+    #[cfg(feature = "system")]
+    let link_include = system();
+    #[cfg(not(feature = "system"))]
+    let link_include = local();
 
-  println!("cargo:rustc-link-lib=dylib=delayimp");
+    println!("cargo:rustc-link-lib=dylib=delayimp");
 
-  // Architecture-specific configuration
-  let (winfsp_lib, clang_target) = match (target_arch.as_str(), target_env.as_str()) {
-    ("x86_64", "msvc") => ("winfsp-x64", "x86_64-pc-windows-msvc"),
-    ("x86", "msvc") => ("winfsp-x86", "x86-pc-windows-msvc"),
-    ("aarch64", "msvc") => ("winfsp-a64", "aarch64-pc-windows-msvc"),
-    _ => panic!("unsupported triple {}", env::var("TARGET").unwrap()),
-  };
+    // Architecture-specific configuration
+    let (winfsp_lib, clang_target) = match (target_arch.as_str(), target_env.as_str()) {
+        ("x86_64", "msvc") => ("winfsp-x64", "x86_64-pc-windows-msvc"),
+        ("x86", "msvc") => ("winfsp-x86", "x86-pc-windows-msvc"),
+        ("aarch64", "msvc") => ("winfsp-a64", "aarch64-pc-windows-msvc"),
+        _ => panic!("unsupported triple {}", env::var("TARGET").unwrap()),
+    };
 
-  println!("cargo:rustc-link-lib=dylib={}", winfsp_lib);
-  println!("cargo:rustc-link-arg=/DELAYLOAD:{}.dll", winfsp_lib);
+    println!("cargo:rustc-link-lib=dylib={}", winfsp_lib);
+    println!("cargo:rustc-link-arg=/DELAYLOAD:{}.dll", winfsp_lib);
 
-  let bindings_path_str = out_dir.join("bindings.rs");
+    let bindings_path_str = out_dir.join("bindings.rs");
 
-  if !Path::new(&bindings_path_str).exists() {
-    let gen_h_path = out_dir.join("gen.h");
-    let mut gen_h = File::create(&gen_h_path).expect("could not create file");
-    gen_h
-      .write_all(HEADER.as_bytes())
-      .expect("could not write header file");
+    if !Path::new(&bindings_path_str).exists() {
+        let gen_h_path = out_dir.join("gen.h");
+        let mut gen_h = File::create(&gen_h_path).expect("could not create file");
+        gen_h
+            .write_all(HEADER.as_bytes())
+            .expect("could not write header file");
 
-    let bindings = bindgen::Builder::default()
-      .header(gen_h_path.to_str().unwrap())
-      .derive_default(true)
-      .blocklist_type("_?P?IMAGE_TLS_DIRECTORY.*")
-      .allowlist_function("Fsp.*")
-      .allowlist_type("FSP.*")
-      .allowlist_type("Fsp.*")
-      .allowlist_var("FSP_.*")
-      .allowlist_var("Fsp.*")
-      .allowlist_var("CTL_CODE")
-      .clang_arg("-DUNICODE")
-      .clang_arg(link_include);
+        let bindings = bindgen::Builder::default()
+            .header(gen_h_path.to_str().unwrap())
+            .derive_default(true)
+            .blocklist_type("_?P?IMAGE_TLS_DIRECTORY.*")
+            .allowlist_function("Fsp.*")
+            .allowlist_type("FSP.*")
+            .allowlist_type("Fsp.*")
+            .allowlist_var("FSP_.*")
+            .allowlist_var("Fsp.*")
+            .allowlist_var("CTL_CODE")
+            .clang_arg("-DUNICODE")
+            .clang_arg(link_include);
 
-    let bindings = bindings.clang_arg(&format!("--target={}", clang_target));
+        let bindings = bindings.clang_arg(&format!("--target={}", clang_target));
 
-    let bindings = bindings
-      .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-      .generate()
-      .expect("Unable to generate bindings");
+        let bindings = bindings
+            .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+            .generate()
+            .expect("Unable to generate bindings");
 
-    bindings
-      .write_to_file(out_dir.join("bindings.rs"))
-      .expect("Couldn't write bindings!");
-  }
+        bindings
+            .write_to_file(out_dir.join("bindings.rs"))
+            .expect("Couldn't write bindings!");
+    }
 }

--- a/winfsp-sys/build.rs
+++ b/winfsp-sys/build.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 #[cfg(feature = "system")]
-use windows_registry::{LOCAL_MACHINE, Value};
+use windows_registry::{Value, LOCAL_MACHINE};
 
 static HEADER: &str = r#"
 #include <winfsp/winfsp.h>
@@ -13,116 +13,101 @@ static HEADER: &str = r#"
 
 #[cfg(not(feature = "system"))]
 fn local() -> String {
-    let project_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+  let project_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 
-    println!(
-        "cargo:rustc-link-search={}",
-        project_dir.join("winfsp/lib").to_string_lossy()
-    );
+  println!(
+    "cargo:rustc-link-search={}",
+    project_dir.join("winfsp/lib").to_string_lossy()
+  );
 
-    "--include-directory=winfsp/inc".into()
+  "--include-directory=winfsp/inc".into()
 }
 
 #[cfg(feature = "system")]
 fn system() -> String {
-    let winfsp_install = LOCAL_MACHINE
-        .open("SOFTWARE\\WOW6432Node\\WinFsp")
-        .ok()
-        .and_then(|u| u.get_value("InstallDir").ok())
-        .expect("WinFsp installation directory not found.");
-    let directory = match winfsp_install {
-        Value::String(string) => string,
-        _ => panic!("unexpected install directory"),
-    };
+  let winfsp_install = LOCAL_MACHINE
+    .open("SOFTWARE\\WOW6432Node\\WinFsp")
+    .ok()
+    .and_then(|u| u.get_value("InstallDir").ok())
+    .expect("WinFsp installation directory not found.");
+  let directory = match winfsp_install {
+    Value::String(string) => string,
+    _ => panic!("unexpected install directory"),
+  };
 
-    println!("cargo:rustc-link-search={}/lib", directory);
+  println!("cargo:rustc-link-search={}/lib", directory);
 
-    format!("--include-directory={}/inc", directory)
+  format!("--include-directory={}/inc", directory)
 }
 
 fn main() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+  let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    // host needs to be windows
-    if cfg!(feature = "docsrs") {
-        println!("cargo:warning=WinFSP does not build on any operating system but Windows. This feature is meant for docs.rs only. It will not link when compiled into a binary.");
-        File::create(out_dir.join("bindings.rs")).unwrap();
-        return;
-    }
+  // host needs to be windows
+  if cfg!(feature = "docsrs") {
+    println!("cargo:warning=WinFSP does not build on any operating system but Windows. This feature is meant for docs.rs only. It will not link when compiled into a binary.");
+    File::create(out_dir.join("bindings.rs")).unwrap();
+    return;
+  }
 
-    if !cfg!(windows) {
-        panic!("WinFSP is only supported on Windows.");
-    }
+  // Use the target OS configuration instead of the host OS configuration to enable cross-platform compilation
+  let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "unknown".to_string());
+  let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "unknown".to_string());
+  let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_else(|_| "unknown".to_string());
 
-    #[cfg(feature = "system")]
-    let link_include = system();
-    #[cfg(not(feature = "system"))]
-    let link_include = local();
+  if target_os != "windows" {
+    panic!("WinFSP is only supported on Windows.");
+  }
 
-    println!("cargo:rustc-link-lib=dylib=delayimp");
+  #[cfg(feature = "system")]
+  let link_include = system();
+  #[cfg(not(feature = "system"))]
+  let link_include = local();
 
-    if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") && cfg!(target_env = "msvc") {
-        println!("cargo:rustc-link-lib=dylib=winfsp-x64");
-        println!("cargo:rustc-link-arg=/DELAYLOAD:winfsp-x64.dll");
-    } else if cfg!(target_os = "windows") && cfg!(target_arch = "x86") && cfg!(target_env = "msvc")
-    {
-        println!("cargo:rustc-link-lib=dylib=winfsp-x86");
-        println!("cargo:rustc-link-arg=/DELAYLOAD:winfsp-x86.dll");
-    } else if cfg!(target_arch = "aarch64") && cfg!(target_env = "msvc") {
-        println!("cargo:rustc-link-lib=dylib=winfsp-a64");
-        println!("cargo:rustc-link-arg=/DELAYLOAD:winfsp-a64.dll");
-    } else {
-        panic!("unsupported triple {}", env::var("TARGET").unwrap())
-    }
+  println!("cargo:rustc-link-lib=dylib=delayimp");
 
-    let bindings_path_str = out_dir.join("bindings.rs");
+  // Architecture-specific configuration
+  let (winfsp_lib, clang_target) = match (target_arch.as_str(), target_env.as_str()) {
+    ("x86_64", "msvc") => ("winfsp-x64", "x86_64-pc-windows-msvc"),
+    ("x86", "msvc") => ("winfsp-x86", "x86-pc-windows-msvc"),
+    ("aarch64", "msvc") => ("winfsp-a64", "aarch64-pc-windows-msvc"),
+    _ => panic!("unsupported triple {}", env::var("TARGET").unwrap()),
+  };
 
-    if !Path::new(&bindings_path_str).exists() {
-        let gen_h_path = out_dir.join("gen.h");
-        let mut gen_h = File::create(&gen_h_path).expect("could not create file");
-        gen_h
-            .write_all(HEADER.as_bytes())
-            .expect("could not write header file");
+  println!("cargo:rustc-link-lib=dylib={}", winfsp_lib);
+  println!("cargo:rustc-link-arg=/DELAYLOAD:{}.dll", winfsp_lib);
 
-        let bindings = bindgen::Builder::default()
-            .header(gen_h_path.to_str().unwrap())
-            .derive_default(true)
-            .blocklist_type("_?P?IMAGE_TLS_DIRECTORY.*")
-            .allowlist_function("Fsp.*")
-            .allowlist_type("FSP.*")
-            .allowlist_type("Fsp.*")
-            .allowlist_var("FSP_.*")
-            .allowlist_var("Fsp.*")
-            .allowlist_var("CTL_CODE")
-            .clang_arg("-DUNICODE")
-            .clang_arg(link_include);
+  let bindings_path_str = out_dir.join("bindings.rs");
 
-        let bindings = if cfg!(target_os = "windows")
-            && cfg!(target_arch = "x86_64")
-            && cfg!(target_env = "msvc")
-        {
-            bindings.clang_arg("--target=x86_64-pc-windows-msvc")
-        } else if cfg!(target_os = "windows")
-            && cfg!(target_arch = "x86")
-            && cfg!(target_env = "msvc")
-        {
-            bindings.clang_arg("--target=x86-pc-windows-msvc")
-        } else if cfg!(target_os = "windows")
-            && cfg!(target_arch = "aarch64")
-            && cfg!(target_env = "msvc")
-        {
-            bindings.clang_arg("--target=aarch64-pc-windows-msvc")
-        } else {
-            panic!("unsupported triple {}", env::var("TARGET").unwrap())
-        };
+  if !Path::new(&bindings_path_str).exists() {
+    let gen_h_path = out_dir.join("gen.h");
+    let mut gen_h = File::create(&gen_h_path).expect("could not create file");
+    gen_h
+      .write_all(HEADER.as_bytes())
+      .expect("could not write header file");
 
-        let bindings = bindings
-            .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-            .generate()
-            .expect("Unable to generate bindings");
+    let bindings = bindgen::Builder::default()
+      .header(gen_h_path.to_str().unwrap())
+      .derive_default(true)
+      .blocklist_type("_?P?IMAGE_TLS_DIRECTORY.*")
+      .allowlist_function("Fsp.*")
+      .allowlist_type("FSP.*")
+      .allowlist_type("Fsp.*")
+      .allowlist_var("FSP_.*")
+      .allowlist_var("Fsp.*")
+      .allowlist_var("CTL_CODE")
+      .clang_arg("-DUNICODE")
+      .clang_arg(link_include);
 
-        bindings
-            .write_to_file(out_dir.join("bindings.rs"))
-            .expect("Couldn't write bindings!");
-    }
+    let bindings = bindings.clang_arg(&format!("--target={}", clang_target));
+
+    let bindings = bindings
+      .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+      .generate()
+      .expect("Unable to generate bindings");
+
+    bindings
+      .write_to_file(out_dir.join("bindings.rs"))
+      .expect("Couldn't write bindings!");
+  }
 }


### PR DESCRIPTION
Background:
On macOS and Linux, you can use cargo-xwin for cross-platform compilation. The existing `cfg!` macro determines the host OS's configuration, causing compilation failures.

So we use TARGET related environment variables to judge and reconstruct the redundant judgment logic.