### PR TITLE
Remove exposing windows-rs types for handle helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
  "clap",
  "tokio",
  "widestring",
- "windows 0.61.1",
+ "windows 0.62.1",
  "winfsp",
 ]
 

--- a/filesystems/ntptfs-winfsp-rs/Cargo.toml
+++ b/filesystems/ntptfs-winfsp-rs/Cargo.toml
@@ -8,11 +8,11 @@ description = "NTFS Passthrough File System via winfsp-rs"
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
-windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_WindowsProgramming", "Win32_System_Console", "Win32_System_IO", "Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Wdk_Storage_FileSystem_Minifilters", "Wdk_System_SystemServices", "Win32_System_Ioctl", "Win32_System_SystemServices", "Win32_System_Threading"] }
+windows = { version = "0.62", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_WindowsProgramming", "Win32_System_Console", "Win32_System_IO", "Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Wdk_Storage_FileSystem_Minifilters", "Wdk_System_SystemServices", "Win32_System_Ioctl", "Win32_System_SystemServices", "Win32_System_Threading"] }
 
 bytemuck = "1.12.1"
 widestring = "1"
-winfsp = { path = "../../winfsp", features = ["debug", "system", "full", "windows-61", "handle-util"] }
+winfsp = { path = "../../winfsp", features = ["debug", "system", "full", "windows-62", "handle-util"] }
 anyhow = "1"
 tokio =  { version = "1.32.0", features = ["rt", "rt-multi-thread"] }
 

--- a/filesystems/ntptfs-winfsp-rs/src/fs/file.rs
+++ b/filesystems/ntptfs-winfsp-rs/src/fs/file.rs
@@ -25,7 +25,7 @@ impl NtPassthroughFile {
 
     /// Get a HANDLE to this file entry.
     pub fn handle(&self) -> HANDLE {
-        self.handle.handle()
+        HANDLE(self.handle.handle())
     }
 
     pub fn handle_ref(&self) -> &AtomicHandle<NtHandleDrop> {

--- a/filesystems/ntptfs-winfsp-rs/src/native/lfs/async_io.rs
+++ b/filesystems/ntptfs-winfsp-rs/src/native/lfs/async_io.rs
@@ -1,7 +1,6 @@
 use crate::native::lfs;
 use std::cell::UnsafeCell;
 use std::future::Future;
-use std::io::ErrorKind;
 use std::mem::MaybeUninit;
 use std::pin::Pin;
 use std::ptr::addr_of;
@@ -117,7 +116,7 @@ pub async fn lfs_read_file_async(
     offset: u64,
     bytes_transferred: &mut u32,
 ) -> winfsp::Result<()> {
-    let handle = AssertThreadSafe(handle.handle());
+    let handle = AssertThreadSafe(HANDLE(handle.handle()));
     let transferred = async move {
         let lfs = LfsReadFuture::new(handle, buffer, offset as i64)?;
         lfs.await.map(|iosb| iosb.Information)
@@ -217,7 +216,7 @@ pub async fn lfs_write_file_async(
     bytes_transferred: &mut u32,
 ) -> winfsp::Result<()> {
     let transferred = async move {
-        let lfs = LfsWriteFuture::new(handle.handle(), buffer, offset as i64)?;
+        let lfs = LfsWriteFuture::new(HANDLE(handle.handle()), buffer, offset as i64)?;
         lfs.await.map(|iosb| iosb.Information)
     }
     .await?;
@@ -340,7 +339,7 @@ pub async fn lfs_query_directory_file_async(
     restart_scan: bool,
 ) -> winfsp::Result<usize> {
     let query_ft = LfsQueryDirectoryFileFuture::new(
-        handle.handle(),
+        HANDLE(handle.handle()),
         file_name,
         buffer,
         return_single_entry,

--- a/filesystems/ntptfs-winfsp-rs/src/native/lfs/mod.rs
+++ b/filesystems/ntptfs-winfsp-rs/src/native/lfs/mod.rs
@@ -113,12 +113,12 @@ pub fn lfs_create_file(
 
     let mut iosb: MaybeUninit<IO_STATUS_BLOCK> = MaybeUninit::uninit();
 
-    let mut handle = NtSafeHandle::from(INVALID_HANDLE_VALUE);
+    let mut handle = NtSafeHandle::from(INVALID_HANDLE_VALUE.0);
     let ea_buffer: Option<&[u8]> = ea_buffer.as_deref();
 
     unsafe {
         NtCreateFile(
-            handle.deref_mut(),
+            *handle.deref_mut() as *mut _,
             FILE_READ_ATTRIBUTES | desired_access,
             &object_attrs,
             iosb.as_mut_ptr(),
@@ -164,11 +164,11 @@ pub fn lfs_open_file(
     );
 
     let mut iosb: MaybeUninit<IO_STATUS_BLOCK> = MaybeUninit::uninit();
-    let mut handle = NtSafeHandle::from(INVALID_HANDLE_VALUE);
+    let mut handle = NtSafeHandle::from(INVALID_HANDLE_VALUE.0);
 
     unsafe {
         NtOpenFile(
-            handle.deref_mut(),
+            *handle.deref_mut() as *mut _,
             (FILE_READ_ATTRIBUTES | desired_access | SYNCHRONIZE).0,
             &object_attrs,
             iosb.as_mut_ptr(),

--- a/winfsp/Cargo.toml
+++ b/winfsp/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/SnowflakePowered/winfsp-rs"
 
 [dependencies]
 winfsp-sys = { path = "../winfsp-sys", version = "0.3" }
-windows = { package = "windows", version = "0.61.1", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_WindowsProgramming", "Win32_System_Console", "Win32_System_Threading", "Win32_System_ProcessStatus", "Wdk_Foundation"] }
+windows = { version = "0.61.1", features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_WindowsProgramming", "Win32_System_Console", "Win32_System_Threading", "Win32_System_ProcessStatus", "Wdk_Foundation"] }
 
 widestring = "1"
 thiserror = "2"
@@ -25,18 +25,17 @@ windows-60 = { package = "windows", version = "0.60", features = ["Win32_Foundat
 windows-62 = { package = "windows", version = "0.62", features = ["Win32_Foundation"], optional = true }
 
 [features]
-default = ["full"]
+default = ["full", "handle-util"]
 debug = []
 system = ["windows/Win32_System_Registry", "winfsp-sys/system"]
 notify = []
 build = []
 delayload = ["build"]
 docsrs = ["winfsp-sys/docsrs"]
-windows-rs = ["handle-util", "windows-rs-error"]
-windows-rs-error = []
 handle-util = []
 async-io = []
 full = ["notify", "delayload", "async-io"]
+
 windows-61 = []
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Makes things a bit more boilerplate-y but worth it to avoid API conflicts