### PR TITLE
feat: support *-pc-windows-gnullvm targets

### DIFF
--- a/winfsp-sys/build.rs
+++ b/winfsp-sys/build.rs
@@ -29,10 +29,17 @@ fn system() -> String {
         panic!("'system' feature not supported for cross-platform compilation.");
     }
 
-    let directory = LOCAL_MACHINE
-        .open("SOFTWARE\\WOW6432Node\\WinFsp")
-        .ok()
-        .and_then(|u| u.get_string("InstallDir").ok())
+    // 32-bit installers land in WOW6432Node; ARM64 native installers
+    // write directly under SOFTWARE. Try both so that an ARM64 host
+    // with a native WinFsp install still resolves headers + libs.
+    let directory = ["SOFTWARE\\WOW6432Node\\WinFsp", "SOFTWARE\\WinFsp"]
+        .iter()
+        .find_map(|p| {
+            LOCAL_MACHINE
+                .open(p)
+                .ok()
+                .and_then(|u| u.get_string("InstallDir").ok())
+        })
         .expect("WinFsp installation directory not found.");
 
     println!("cargo:rustc-link-search={}/lib", directory);
@@ -81,6 +88,41 @@ fn copy_winfsp_dll(winfsp_lib: &str) {
     }
 }
 
+/// Linkage environment for the active target.
+///
+/// WinFSP ships MSVC-format `.lib` import libraries; both classic MSVC
+/// and `*-pc-windows-gnullvm` consume them through `lld-link`, so the
+/// link decisions are nearly identical between the two — but the clang
+/// `--target`, the delay-load syntax, and whether we ask rustc for
+/// `delayimp` all diverge, so we keep them as distinct cases.
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum LinkEnv {
+    Msvc,
+    GnuLlvm,
+}
+
+impl LinkEnv {
+    fn detect(target_env: &str, target_abi: &str) -> Option<Self> {
+        match (target_env, target_abi) {
+            ("msvc", _) => Some(Self::Msvc),
+            ("gnu", "llvm") => Some(Self::GnuLlvm),
+            _ => None,
+        }
+    }
+
+    fn clang_target(self, target_arch: &str) -> Option<&'static str> {
+        Some(match (self, target_arch) {
+            (Self::Msvc, "x86_64") => "x86_64-pc-windows-msvc",
+            (Self::Msvc, "x86") => "x86-pc-windows-msvc",
+            (Self::Msvc, "aarch64") => "aarch64-pc-windows-msvc",
+            (Self::GnuLlvm, "x86_64") => "x86_64-w64-mingw32",
+            (Self::GnuLlvm, "x86") => "i686-w64-mingw32",
+            (Self::GnuLlvm, "aarch64") => "aarch64-w64-mingw32",
+            _ => return None,
+        })
+    }
+}
+
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
@@ -95,28 +137,45 @@ fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "unknown".to_string());
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "unknown".to_string());
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_else(|_| "unknown".to_string());
+    let target_abi = env::var("CARGO_CFG_TARGET_ABI").unwrap_or_default();
 
     if target_os != "windows" {
         panic!("WinFSP is only supported on Windows.");
     }
+
+    let link_env = LinkEnv::detect(&target_env, &target_abi)
+        .unwrap_or_else(|| panic!("unsupported triple {}", env::var("TARGET").unwrap()));
 
     #[cfg(feature = "system")]
     let link_include = system();
     #[cfg(not(feature = "system"))]
     let link_include = local();
 
-    println!("cargo:rustc-link-lib=dylib=delayimp");
-
-    // Architecture-specific configuration
-    let (winfsp_lib, clang_target) = match (target_arch.as_str(), target_env.as_str()) {
-        ("x86_64", "msvc") => ("winfsp-x64", "x86_64-pc-windows-msvc"),
-        ("x86", "msvc") => ("winfsp-x86", "x86-pc-windows-msvc"),
-        ("aarch64", "msvc") => ("winfsp-a64", "aarch64-pc-windows-msvc"),
+    let winfsp_lib = match target_arch.as_str() {
+        "x86_64" => "winfsp-x64",
+        "x86" => "winfsp-x86",
+        "aarch64" => "winfsp-a64",
         _ => panic!("unsupported triple {}", env::var("TARGET").unwrap()),
     };
+    let clang_target = link_env
+        .clang_target(&target_arch)
+        .unwrap_or_else(|| panic!("unsupported triple {}", env::var("TARGET").unwrap()));
 
     println!("cargo:rustc-link-lib=dylib={}", winfsp_lib);
-    println!("cargo:rustc-link-arg=/DELAYLOAD:{}.dll", winfsp_lib);
+    match link_env {
+        LinkEnv::Msvc => {
+            // delayimp.lib provides __delayLoadHelper2 under MSVC.
+            println!("cargo:rustc-link-lib=dylib=delayimp");
+            println!("cargo:rustc-link-arg=/DELAYLOAD:{}.dll", winfsp_lib);
+        }
+        LinkEnv::GnuLlvm => {
+            // LLVM-MinGW's libdelayimp.a isn't on rustc's link search
+            // path by default; lld-link's --delayload lowering provides
+            // the helper itself, and ld.lld in mingw mode requires the
+            // GNU-style flag rather than MSVC's `/DELAYLOAD:`.
+            println!("cargo:rustc-link-arg=-Wl,--delayload={}.dll", winfsp_lib);
+        }
+    }
 
     let bindings_path_str = out_dir.join("bindings.rs");
 
@@ -141,6 +200,18 @@ fn main() {
             .clang_arg(link_include);
 
         let bindings = bindings.clang_arg(&format!("--target={}", clang_target));
+
+        // Under mingw/llvm-mingw clang defaults to C99, which rejects the
+        // `static_assert(e,m)` MSVC C extension used in winfsp/fsctl.h.
+        // C11 has it via <assert.h> macro mapping; ensure that mode + the
+        // standard headers are pulled in.
+        let bindings = match link_env {
+            LinkEnv::GnuLlvm => bindings
+                .clang_arg("-std=c11")
+                .clang_arg("-include")
+                .clang_arg("assert.h"),
+            LinkEnv::Msvc => bindings,
+        };
 
         let bindings = bindings
             .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))

--- a/winfsp/src/init.rs
+++ b/winfsp/src/init.rs
@@ -17,7 +17,7 @@ use crate::Result;
 pub struct FspInit;
 
 #[cfg(feature = "system")]
-fn get_system_winfsp() -> Option<windows::core::HSTRING> {
+fn read_install_dir(subkey: PCWSTR) -> Option<std::ffi::OsString> {
     use crate::constants::MAX_PATH;
     use windows::Win32::System::Registry::{HKEY_LOCAL_MACHINE, RRF_RT_REG_SZ, RegGetValueW};
 
@@ -26,7 +26,7 @@ fn get_system_winfsp() -> Option<windows::core::HSTRING> {
     let status = unsafe {
         RegGetValueW(
             HKEY_LOCAL_MACHINE,
-            w!("SOFTWARE\\WOW6432Node\\WinFsp"),
+            subkey,
             w!("InstallDir"),
             RRF_RT_REG_SZ,
             None,
@@ -36,14 +36,17 @@ fn get_system_winfsp() -> Option<windows::core::HSTRING> {
     };
     if status.is_err() {
         return None;
-    };
+    }
+    let path = U16CStr::from_slice(&path[0..(size as usize) / std::mem::size_of::<u16>()]).ok()?;
+    Some(path.to_os_string())
+}
 
-    let Ok(path) = U16CStr::from_slice(&path[0..(size as usize) / std::mem::size_of::<u16>()])
-    else {
-        return None;
-    };
-
-    let mut directory = path.to_os_string();
+#[cfg(feature = "system")]
+fn get_system_winfsp() -> Option<windows::core::HSTRING> {
+    // 32-bit installers land in WOW6432Node; ARM64 native installers
+    // write directly under SOFTWARE.
+    let mut directory = read_install_dir(w!("SOFTWARE\\WOW6432Node\\WinFsp"))
+        .or_else(|| read_install_dir(w!("SOFTWARE\\WinFsp")))?;
     directory.push("\\bin\\");
 
     if cfg!(target_arch = "x86_64") {
@@ -113,24 +116,57 @@ pub fn winfsp_init_or_die() -> FspInit {
     FspInit
 }
 
+/// Linkage environment for the active build target.
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum LinkEnv {
+    Msvc,
+    GnuLlvm,
+}
+
+impl LinkEnv {
+    fn detect(target_env: &str, target_abi: &str) -> Option<Self> {
+        match (target_env, target_abi) {
+            ("msvc", _) => Some(Self::Msvc),
+            ("gnu", "llvm") => Some(Self::GnuLlvm),
+            _ => None,
+        }
+    }
+}
+
 /// Build-time helper to enable `DELAYLOAD` linking to the system WinFSP.
 ///
-/// This function should be called from `build.rs`.
+/// This function should be called from `build.rs`. Reads target config
+/// from cargo env vars so cross-compiled build scripts work correctly.
 pub fn winfsp_link_delayload() {
-    if cfg!(all(target_os = "windows", target_env = "msvc")) {
-        if cfg!(target_arch = "x86_64") {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    let target_abi = std::env::var("CARGO_CFG_TARGET_ABI").unwrap_or_default();
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+
+    if target_os != "windows" {
+        panic!("unsupported triple");
+    }
+    let link_env = LinkEnv::detect(&target_env, &target_abi)
+        .unwrap_or_else(|| panic!("unsupported triple"));
+
+    let dll = match target_arch.as_str() {
+        "x86_64" => "winfsp-x64.dll",
+        "x86" => "winfsp-x86.dll",
+        "aarch64" => "winfsp-a64.dll",
+        _ => panic!("unsupported architecture"),
+    };
+
+    match link_env {
+        LinkEnv::Msvc => {
             println!("cargo:rustc-link-lib=dylib=delayimp");
-            println!("cargo:rustc-link-arg=/DELAYLOAD:winfsp-x64.dll");
-        } else if cfg!(target_arch = "x86") {
-            println!("cargo:rustc-link-lib=dylib=delayimp");
-            println!("cargo:rustc-link-arg=/DELAYLOAD:winfsp-x86.dll");
-        } else if cfg!(target_arch = "aarch64") {
-            println!("cargo:rustc-link-lib=dylib=delayimp");
-            println!("cargo:rustc-link-arg=/DELAYLOAD:winfsp-a64.dll");
-        } else {
-            panic!("unsupported architecture")
+            println!("cargo:rustc-link-arg=/DELAYLOAD:{dll}");
         }
-    } else {
-        panic!("unsupported triple")
+        LinkEnv::GnuLlvm => {
+            // LLVM-MinGW's libdelayimp.a isn't on rustc's link search
+            // path by default; lld-link's --delayload lowering provides
+            // the helper itself, and ld.lld in mingw mode requires the
+            // GNU-style flag rather than MSVC's `/DELAYLOAD:`.
+            println!("cargo:rustc-link-arg=-Wl,--delayload={dll}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Lift the MSVC-only build gates so `*-pc-windows-gnullvm` Rust toolchains can build against WinFSP. The same MSVC-format `.lib` import libraries the crate already ships are consumed by `lld-link` (which both `*-pc-windows-msvc` and `*-pc-windows-gnullvm` use as their linker), so this is purely an unblocking change — no new shipped artefacts, no new dependencies.

The motivating consumer ([`ext4-win-driver`](https://github.com/antimatter-studios/ext4-win-driver), Windows 11 ARM64) needs to build with the rustup-shipped `aarch64-pc-windows-gnullvm` toolchain plus LLVM-MinGW. With `0.12.4` head, `winfsp-sys/build.rs` panics with `unsupported triple`. With this branch, `cargo build --features mount` succeeds, the resulting binary mounts an ext4 image through WinFSP, and ops/teardown round-trip cleanly.

## What changes

`winfsp-sys/build.rs`:

- Introduce a `LinkEnv { Msvc, GnuLlvm }` enum. `LinkEnv::detect(target_env, target_abi)` returns `Some(Msvc)` for `target_env == "msvc"`, `Some(GnuLlvm)` for `target_env == "gnu" && target_abi == "llvm"`, and `None` otherwise (which panics with `unsupported triple`). The enum drives the clang `--target` (`LinkEnv::clang_target(arch)` is one flat 6-arm match), the delay-load syntax, the `delayimp` decision, and the C11/`<assert.h>` injection.
- The arch→lib selection is its own flat match on `target_arch.as_str()` (`"x86_64" => "winfsp-x64"`, …), no longer interleaved with the env selection. Inline `if is_gnullvm { ... } else { ... }` ternaries are gone — every branch is an explicit enum arm.
- Use mingw clang target strings (`aarch64-w64-mingw32` etc.) under `LinkEnv::GnuLlvm` so bindgen picks up LLVM-MinGW's bundled `windows.h` instead of the absent MSVC SDK headers; struct layout stays MS-ABI.
- Force `-std=c11` + auto-include `<assert.h>` for gnullvm so `winfsp/fsctl.h`'s `static_assert(...)` parses (mingw clang defaults to C99).
- Skip emitting `cargo:rustc-link-lib=dylib=delayimp` under gnullvm — rustc doesn't know LLVM-MinGW's lib path for `libdelayimp.a`, and `lld-link`'s `--delayload` lowering provides the helper itself.
- Emit `-Wl,--delayload=foo.dll` for gnullvm vs `/DELAYLOAD:foo.dll` for MSVC — `ld.lld` in mingw mode rejects the MSVC slash-form syntax.
- `system()` now tries `SOFTWARE\WOW6432Node\WinFsp` first, then falls back to `SOFTWARE\WinFsp`. The Windows ARM64 native installer registers `InstallDir` outside the WOW6432Node redirector, so the fallback lets the same `system`-feature build resolve headers + import libs on ARM64 the same way it does on x64.

`winfsp/src/init.rs`:

- Mirror the typed `LinkEnv` in `winfsp_link_delayload`, with explicit `LinkEnv::Msvc` / `LinkEnv::GnuLlvm` arms — no `else` fallthrough to GNU linkage. Anything `LinkEnv::detect` doesn't recognise panics with `unsupported triple` before the match.
- Read `CARGO_CFG_TARGET_*` instead of `cfg!()` so cross-built build scripts get the *target's* view (the `cfg!()` form evaluated against the build script's host, which made cross-builds panic with `unsupported triple` even when the target was supported).
- `get_system_winfsp()` falls back to `SOFTWARE\WinFsp` after the `WOW6432Node` lookup, mirroring the build-time change.

`winfsp/Cargo.toml`:

- Unchanged — `system = ["windows/Win32_System_Registry", "winfsp-sys/system"]`. (An earlier revision of this PR decoupled the cascade; that's been reverted in favour of fixing the underlying registry-path issue above, per review.)

## Test plan

Verified at the **previous revision (`f89af0b`)** on Windows 11 ARM64 (`aarch64-pc-windows-gnullvm` + WinFSP 2.1):

- [x] `cargo build --release --features mount`
- [x] WinFSP mount creates a drive letter, ext4 ops round-trip, taskkill teardown is clean
- [x] Existing `*-pc-windows-msvc` paths unchanged — the MSVC arms of every match are untouched

The current revision (`2f1ea36`) is a mechanical refactor of the above (`LinkEnv` enum + registry fallback) and isn't yet re-verified end-to-end. Happy to repeat the mount test before merge if you'd like.

Untested by me (would appreciate review / CI):

- [ ] `*-pc-windows-msvc` still green on CI
- [ ] x86_64 (non-aarch64) gnullvm — I only have an ARM64 VM
- [ ] `system` feature on an x64 host where the install lands in `WOW6432Node\WinFsp` (the fallback puts that path first, so behaviour should be identical to before)